### PR TITLE
Interfaz unal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "strapi-plugin-sso",
-  "version": "0.4.4",
+  "name": "webunal-login",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "strapi-plugin-sso",
-      "version": "0.4.4",
+      "name": "webunal-login",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "generate-password": "^1.7.1",

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,5 +1,4 @@
 "use strict";
-
 module.exports = {
   default: {
     REMEMBER_ME: false,
@@ -7,6 +6,7 @@ module.exports = {
       "http://localhost:1337/webunal-login/google/callback",
     GOOGLE_GSUITE_HD: "",
     GOOGLE_ALIAS: "",
+    CUSTOM_GOOGLE_SIGNIN_URL: "", // Añadir esta línea para permitir la personalización
   },
   validator() {},
 };

--- a/server/controllers/google.js
+++ b/server/controllers/google.js
@@ -27,7 +27,7 @@ const OAUTH_SCOPE =
   "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
 
   async function renderLoginPage(ctx) {
-    //Cambiar por la página real, redirigir con el botón a  /webunal-login/google
+    //Cambiar por la página real, redirigir con el botón a  /webunal-login/google.
     ctx.body = `
       <!DOCTYPE html>
       <html>

--- a/server/controllers/google.js
+++ b/server/controllers/google.js
@@ -26,6 +26,22 @@ const OAUTH_RESPONSE_TYPE = "code";
 const OAUTH_SCOPE =
   "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
 
+  async function renderLoginPage(ctx) {
+    ctx.body = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Login Page</title>
+        </head>
+        <body>
+          <h1>Iniciar sesión</h1>
+          <!-- Usamos un enlace para la redirección -->
+          <a href="/webunal-login/google" id="login-link">Iniciar sesión con Google</a>
+        </body>
+      </html>
+    `;
+  }
+
 /**
  * Redirect to Google
  * @param ctx
@@ -137,6 +153,7 @@ async function googleSignInCallback(ctx) {
 }
 
 module.exports = {
+  renderLoginPage,
   googleSignIn,
   googleSignInCallback,
 };

--- a/server/controllers/google.js
+++ b/server/controllers/google.js
@@ -27,6 +27,7 @@ const OAUTH_SCOPE =
   "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile";
 
   async function renderLoginPage(ctx) {
+    //Cambiar por la página real, redirigir con el botón a  /webunal-login/google
     ctx.body = `
       <!DOCTYPE html>
       <html>

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,8 +1,16 @@
 module.exports = [
   {
     method: "GET",
+    path: "/login",
+    handler: "google.renderLoginPage", // Nuevo controlador para la interfaz
+    config: {
+      auth: false,
+    },
+  },
+  {
+    method: "GET",
     path: "/google",
-    handler: "google.googleSignIn",
+    handler: "google.googleSignIn", // Mantiene la lógica de redirección a Google
     config: {
       auth: false,
     },


### PR DESCRIPTION
-Se agregó una nueva ruta /webunal-login/login, la cual se usa para mostrar la interfaz deseada
- Se debe agregar la página en el archivo \src\plugins\webunal-login\server\controllers\google.js, en la función renderLoginPage